### PR TITLE
Add reactive bindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# J C U R R Y (curry.ts)
+# JCURRY (curry.ts)
 
 The successor to the most known word in the javascript universe. Every person who came within 5km radius of an IDE has heard of that word. Some shiver, some get excited, some faint when they hear it. What if I told you that you don't need a 40k behemoth of a javascript object? That you actually just need a little curry in your life instead?
 
@@ -55,7 +55,6 @@ Other selectors are mainly used to narrow this list down to specific nodes. The 
 ```ts
 type NarrowSelector = string | Node | Node[] | HTMLCollection | Curry
 ```
-
 
 ## $()
 
@@ -577,13 +576,39 @@ $('ul > li')
 
 ## Manipulators
 
-[add](#add) • [prepend](#prepend) • [append](#append) • [addChild](#addChild) • [prependChild](#prependChild) • [appendChild](#appendChild) • [swap](#swap) • [replace](#replace) • [teleport](#teleport) • [fullscreen](#fullscreen) • [text](#text) • [del](#del)
+[bind](#bind) • [add](#add) • [prepend](#prepend) • [append](#append) • [addChild](#addChild) • [prependChild](#prependChild) • [appendChild](#appendChild) • [swap](#swap) • [replace](#replace) • [teleport](#teleport) • [fullscreen](#fullscreen) • [text](#text) • [del](#del)
 
 
 Methods which directly manipulate the DOM. Used for creating, deleting or moving elements around.
 Those which create elements accept the same time.
 ```ts
 type NewNode = Element | string | Node | Array<Element | string | Node>
+```
+
+## bind
+
+Allows us to bind reactive data to a DOM node. This chain returns an object and
+each time its property is updated, it runs the reactive function. Allowing us to
+update the DOM based on the data.
+
+```ts
+type RawObject = Record<PropertyKey, string | number | boolean | null | undefined>
+type BindFn<T> = (this: HTMLElement, obj: T, instance: Curry) => void
+
+$.bind(data: RawObject, fn: BindFn<typeof data>)
+```
+
+Usage
+```ts
+const binding = $('#app').bind({ count: 0 }, function ({ count }) {
+  this.textContent = `Count is ${count}`
+})
+binding.count++
+binding.count += 10
+// #app.textContent === 11
+
+delete binding.count
+// #app.textContent === 'Count is undefined'
 ```
 ## add
 
@@ -780,8 +805,8 @@ Usage
 ```ts
 // Because chains are async, we have to await them
 // because there could be more chained links which take a while to execute.
-const listItems = await $('li').get();
-const listItemsContents = await $('li').get('textContent');
+const listItems = await $('li').get()
+const listItemsContents = await $('li').get('textContent')
 ```
 
 ---

--- a/dist/curry.mjs
+++ b/dist/curry.mjs
@@ -1,7 +1,7 @@
-var O = Object.defineProperty;
-var H = (t, e, n) => e in t ? O(t, e, { enumerable: !0, configurable: !0, writable: !0, value: n }) : t[e] = n;
-var r = (t, e, n) => (H(t, typeof e != "symbol" ? e + "" : e, n), n);
-const A = function(t, e) {
+var j = Object.defineProperty;
+var O = (t, e, n) => e in t ? j(t, e, { enumerable: !0, configurable: !0, writable: !0, value: n }) : t[e] = n;
+var r = (t, e, n) => (O(t, typeof e != "symbol" ? e + "" : e, n), n);
+const H = function(t, e) {
   return this.queue(() => {
     for (const n of this.nodes)
       if (t)
@@ -22,7 +22,7 @@ const A = function(t, e) {
 function a(t) {
   return t ? Array.isArray(t) : !1;
 }
-function _(t) {
+function w(t) {
   const e = typeof t;
   return t != null && e === "object";
 }
@@ -32,7 +32,7 @@ function I(t) {
 function E(t) {
   return t == null;
 }
-function S(t) {
+function P(t) {
   if (!t || !t.previousElementSibling)
     return 0;
   let e = 0, n = t;
@@ -40,7 +40,7 @@ function S(t) {
     e++;
   return e;
 }
-function P(t, e, n) {
+function C(t, e, n) {
   return this.queue(() => {
     const i = t === "next" ? "nextElementSibling" : "previousElementSibling";
     typeof e != "number" && (n = e, e = void 0);
@@ -51,7 +51,7 @@ function P(t, e, n) {
         f && (s.push(f), n && n.apply(f, [{
           self: f,
           prev: c,
-          index: S(f),
+          index: P(f),
           instance: this
         }]));
       else {
@@ -61,7 +61,7 @@ function P(t, e, n) {
         h && (s.push(h), n && n.apply(h, [{
           self: h,
           prev: c,
-          index: S(c),
+          index: P(c),
           instance: this
         }]));
       }
@@ -73,10 +73,10 @@ function F(t) {
   const e = document.createElement("div");
   return e.insertAdjacentHTML("beforeend", t), e.children[0];
 }
-function $(t = 1) {
+function R(t = 1) {
   return new Promise((e) => setTimeout(e, t));
 }
-function C(t, e) {
+function x(t, e) {
   if (typeof t == "string") {
     let n;
     return e ? n = e.querySelectorAll(t) : n = document.querySelectorAll(t), Array.from(n);
@@ -84,7 +84,7 @@ function C(t, e) {
   return t instanceof HTMLCollection ? Array.from(t) : t instanceof Node ? [t] : t instanceof l ? t.nodes : t;
 }
 const m = (t) => L + t;
-function M(t) {
+function $(t) {
   return this.queue(() => {
     if (this.nodes.length === 0)
       return;
@@ -96,7 +96,7 @@ function M(t) {
     return e.length === 1 ? e[0] : e;
   });
 }
-const N = function(t, e = "every") {
+const M = function(t, e = "every") {
   const n = [];
   for (const i of this.nodes) {
     const s = i;
@@ -114,7 +114,7 @@ const N = function(t, e = "every") {
     case "every":
       return n.every((i) => i);
   }
-}, R = function(t, e, n) {
+}, N = function(t, e, n) {
   return this.queue(async () => {
     const i = [];
     for (const s of this.nodes)
@@ -129,7 +129,7 @@ const N = function(t, e = "every") {
       }));
     return Promise.allSettled(i);
   }), this;
-}, D = function(t) {
+}, Q = function(t) {
   return this.queue(async () => {
     const e = [];
     for (const n of this.nodes)
@@ -140,7 +140,7 @@ const N = function(t, e = "every") {
       }));
     return Promise.allSettled(e);
   }), this;
-}, Q = function(t) {
+}, D = function(t) {
   this.queue(() => {
     for (const e of this.nodes) {
       const n = e;
@@ -209,17 +209,18 @@ const N = function(t, e = "every") {
   return this.queue(
     () => (
       // eslint-disable-next-line no-async-promise-executor
-      new Promise(async () => {
-        let e = 0;
-        for (const n of this.nodes)
-          await new Promise((i) => t.apply(n, [
-            i,
+      new Promise(async (e) => {
+        let n = 0;
+        for (const i of this.nodes)
+          await new Promise((s) => t.apply(i, [
+            s,
             {
-              self: n,
-              index: e,
+              self: i,
+              index: n,
               instance: this
             }
-          ])), e++;
+          ])), n++;
+        e(!0);
       })
     )
   ), this;
@@ -285,9 +286,9 @@ const N = function(t, e = "every") {
     });
   }), this;
 }, tt = function(t, e) {
-  return P.apply(this, ["next", t, e]);
+  return C.apply(this, ["next", t, e]);
 }, et = function(t, e) {
-  return P.apply(this, ["prev", t, e]);
+  return C.apply(this, ["prev", t, e]);
 }, nt = function(t) {
   return this.queue(() => {
     const e = [];
@@ -343,7 +344,7 @@ const ct = function(t, e) {
           const o = Object.keys(s)[0], c = s[o];
           g(i, o, c);
         }
-      else if (_(t)) {
+      else if (w(t)) {
         const s = Object.keys(t)[0], o = t[s];
         g(i, s, o);
       }
@@ -435,8 +436,8 @@ const ct = function(t, e) {
     this.nodes = Array.from(e);
   }), this;
 }, lt = function(t = 1) {
-  return this.queue(() => $(t)), this;
-}, x = function(t, e, n) {
+  return this.queue(() => R(t)), this;
+}, _ = function(t, e, n) {
   var i;
   if (typeof t == "string") {
     const s = (n ?? document).querySelector(t);
@@ -455,8 +456,10 @@ const ct = function(t, e) {
     }
   e && t && ((i = t.parentNode) == null || i.replaceChild(e, t));
 }, at = function(t, e, n) {
-  return this.queue(() => x(t, e ?? this.nodes[0], n)), this;
-}, T = function(t, e, n) {
+  return this.queue(() => {
+    e ? _(t, e, n) : _(this.nodes[0], t, n);
+  }), this;
+}, q = function(t, e, n) {
   if (typeof t == "string") {
     const o = (n ?? document).querySelector(t);
     if (!o)
@@ -470,9 +473,11 @@ const ct = function(t, e) {
     e = o;
   }
   const i = t.cloneNode(!0), s = e.cloneNode(!0);
-  u(i).replace(e), u(s).replace(t);
+  u(e).replace(i), u(t).replace(s);
 }, pt = function(t, e) {
-  return this.queue(() => T(t, e, this.doc)), this;
+  return this.queue(() => {
+    e ? q(t, e, this.doc) : q(this.nodes[0], t, this.doc);
+  }), this;
 }, yt = function(t, e) {
   return this.queue(
     () => new Promise((n) => {
@@ -495,7 +500,7 @@ const ct = function(t, e) {
       });
     })
   ), this;
-}, q = function(t, e = "append") {
+}, v = function(t, e = "append") {
   return this.queue(() => {
     a(t) || (t = [t]);
     for (const n of this.nodes) {
@@ -505,10 +510,10 @@ const ct = function(t, e) {
     }
   }), this;
 }, gt = function(t) {
-  return q.call(this, t, "prepend"), this;
+  return v.call(this, t, "prepend"), this;
 }, bt = function(t) {
-  return q.call(this, t, "append"), this;
-}, w = function(t, e = "append") {
+  return v.call(this, t, "append"), this;
+}, A = function(t, e = "append") {
   return this.queue(() => {
     a(t) || (t = [t]);
     for (const n of this.nodes) {
@@ -518,9 +523,9 @@ const ct = function(t, e) {
     }
   }), this;
 }, mt = function(t) {
-  return w.call(this, t, "prepend"), this;
+  return A.call(this, t, "prepend"), this;
 }, _t = function(t) {
-  return w.call(this, t, "append"), this;
+  return A.call(this, t, "append"), this;
 };
 class qt {
   constructor(e) {
@@ -620,7 +625,7 @@ const vt = function(t, e = {}) {
     }
     return Promise.allSettled(f);
   }), this;
-}, j = async function(t, e, n) {
+}, T = async function(t, e, n) {
   const i = n ?? document;
   if (typeof t == "string") {
     const s = i.querySelector(t);
@@ -631,15 +636,15 @@ const vt = function(t, e = {}) {
   if (t) {
     const s = t;
     return Object.hasOwn(t, "requestFullscreen") ? (i.fullscreenElement && i.exitFullscreen(), s.requestFullscreen(e).then(() => {
-      e != null && e.onOpen && (e == null || e.onOpen());
+      e != null && e.onOpen && (e == null || e.onOpen.apply(t));
     }).catch(
-      (o) => e != null && e.onError ? e == null ? void 0 : e.onError(o) : Promise.reject(Error("[$.fullscreen] Error during initialization."))
+      (o) => e != null && e.onError ? e == null ? void 0 : e.onError.apply(t, [o]) : Promise.reject(Error("[$.fullscreen] Error during initialization."))
     )) : Promise.reject(Error("[$.fullscreen] Target does not implement the fullscreen API"));
   }
   return Promise.reject(Error("[$.fullscreen] Target does not exist"));
-}, Et = function(t, e) {
-  return this.queue(() => (_(t) ? (e = t, t = this.nodes[0]) : t ?? (t = this.nodes[0]), j(t, e, this.doc))), this;
-}, Pt = function(t) {
+}, Pt = function(t, e) {
+  return this.queue(() => (w(t) ? (e = t, t = this.nodes[0]) : t ?? (t = this.nodes[0]), T(t, e, this.doc))), this;
+}, Et = function(t) {
   const { duration: e, to: n, easing: i } = Object.assign({
     duration: 300,
     to: 1,
@@ -675,9 +680,12 @@ const vt = function(t, e = {}) {
   }), this;
 }, Tt = function(t) {
   return t ? (this.queue(async () => await t.call(this)), this) : this;
-}, jt = function(t) {
+}, jt = function(t, e) {
   return this.queue(() => {
-    t && (this.nodes = C(t, this.doc));
+    if (!t)
+      return;
+    const n = x(t, this.doc);
+    this.nodes = e ? [...this.nodes, ...n] : n;
   }), this;
 }, Ot = function(t = 300, e = "linear") {
   return this.queue(async () => {
@@ -715,7 +723,7 @@ const vt = function(t, e = {}) {
       duration: n = 300,
       easing: i = e ?? "linear",
       override: s = !1
-    } = _(t) ? t : {}, o = [];
+    } = w(t) ? t : {}, o = [];
     for (const c of this.nodes) {
       const f = c, h = s ? this.nodes[0].style.display === "none" : f.style.display === "none";
       o.push(
@@ -748,7 +756,7 @@ const vt = function(t, e = {}) {
     }
     this.nodes = e;
   }), this;
-}, $t = function(t) {
+}, Rt = function(t) {
   return this.queue(() => {
     const e = [];
     for (const n of this.nodes) {
@@ -759,17 +767,35 @@ const vt = function(t, e = {}) {
     }
     this.nodes = e;
   }), this;
+}, $t = function(t, e) {
+  for (const n of this.nodes)
+    e.apply(n, [t, this]);
+  return new Proxy(t, {
+    get: (n, i, s) => Reflect.get(n, i, s),
+    set: (n, i, s, o) => {
+      const c = Reflect.set(n, i, s, o);
+      for (const f of this.nodes)
+        e.apply(f, [n, this]);
+      return c;
+    },
+    deleteProperty: (n, i) => {
+      const s = Reflect.deleteProperty(n, i);
+      for (const o of this.nodes)
+        e.apply(o, [n, this]);
+      return s;
+    }
+  });
 };
 function u(t, e) {
   return new l(t, e);
 }
-const v = class {
+const S = class {
   constructor(e, n) {
     r(this, "doc");
     r(this, "nodes");
     r(this, "taskQueue");
     /* ----------  Chaining API  ---------- */
-    r(this, "fullscreen", Et.bind(this));
+    r(this, "fullscreen", Pt.bind(this));
     r(this, "prependChild", mt.bind(this));
     r(this, "toggleClass", W.bind(this));
     r(this, "appendChild", _t.bind(this));
@@ -781,7 +807,7 @@ const v = class {
     r(this, "hasClass", k.bind(this));
     r(this, "teleport", ht.bind(this));
     r(this, "nthChild", yt.bind(this));
-    r(this, "addChild", w.bind(this));
+    r(this, "addChild", A.bind(this));
     r(this, "prepend", gt.bind(this));
     r(this, "setAttr", ct.bind(this));
     r(this, "getAttr", rt.bind(this));
@@ -790,11 +816,11 @@ const v = class {
     r(this, "animate", St.bind(this));
     r(this, "fadeOut", Ct.bind(this));
     r(this, "filter", ut.bind(this));
-    r(this, "fadeIn", Pt.bind(this));
+    r(this, "fadeIn", Et.bind(this));
     r(this, "append", bt.bind(this));
     r(this, "toggle", ot.bind(this));
     r(this, "parent", dt.bind(this));
-    r(this, "click", D.bind(this));
+    r(this, "click", Q.bind(this));
     r(this, "first", G.bind(this));
     r(this, "hover", ft.bind(this));
     r(this, "wait", lt.bind(this));
@@ -802,39 +828,38 @@ const v = class {
     r(this, "show", st.bind(this));
     r(this, "hide", it.bind(this));
     r(this, "query", jt.bind(this));
-    r(this, "text", A.bind(this));
+    r(this, "text", H.bind(this));
     r(this, "each", z.bind(this));
     r(this, "last", J.bind(this));
     r(this, "even", Z.bind(this));
     r(this, "next", tt.bind(this));
     r(this, "prev", et.bind(this));
-    r(this, "add", q.bind(this));
-    r(this, "del", Q.bind(this));
+    r(this, "add", v.bind(this));
+    r(this, "del", D.bind(this));
     r(this, "odd", V.bind(this));
-    r(this, "get", M.bind(this));
+    r(this, "get", $.bind(this));
     r(this, "css", U.bind(this));
     r(this, "nth", Y.bind(this));
     r(this, "run", Tt.bind(this));
     r(this, "key", new qt(this));
-    r(this, "is", N.bind(this));
-    r(this, "on", R.bind(this));
+    r(this, "is", M.bind(this));
+    r(this, "on", N.bind(this));
     r(this, "slideUp", Ot.bind(this));
     r(this, "slideDown", Ht.bind(this));
     r(this, "slideToggle", Lt.bind(this));
     r(this, "siblings", It.bind(this));
     r(this, "prevSiblings", Ft.bind(this));
-    r(this, "nextSiblings", $t.bind(this));
-    this.doc = n, this.nodes = C(e, n), this.taskQueue = Promise.resolve();
+    r(this, "nextSiblings", Rt.bind(this));
+    // Experimental
+    // @ts-expect-error I don't really understand this problem, sorry :/
+    r(this, "bind", $t.bind(this));
+    this.doc = n, this.nodes = x(e, n), this.taskQueue = Promise.resolve();
   }
   /**
    * Functions which return Curry instance can be queued to be asyncronously executed.
    */
   async queue(e) {
     return await (this.taskQueue = this.taskQueue.then(e));
-  }
-  static text(e, n) {
-    const i = u(e);
-    return A.bind(i)(n);
   }
   get length() {
     return this.nodes.length;
@@ -844,13 +869,13 @@ const v = class {
       e(!0);
     }));
   }
-  // Expose prototype so that users can extend curry with their own functions
   /**
    *  Experimental extension API
+   *  Expose prototype so that users can extend curry with their own functions
    */
   static $fn(e, n) {
     Object.defineProperty(
-      v.prototype,
+      S.prototype,
       e,
       {
         value() {
@@ -860,10 +885,13 @@ const v = class {
     );
   }
 };
-let l = v;
+let l = S;
 /* ----------  Static API  ---------- */
-r(l, "fullscreen", j), r(l, "replace", x), r(l, "swap", T);
+r(l, "fullscreen", T), r(l, "replace", _), r(l, "swap", q);
 export {
   u as $,
-  l as Curry
+  l as Curry,
+  T as fullscreen,
+  _ as replace,
+  q as swap
 };

--- a/dist/curry/index.d.ts
+++ b/dist/curry/index.d.ts
@@ -35,6 +35,7 @@ import type { Run } from './modules/run';
 import type { Query } from './modules/query';
 import type { Slide, SlideToggle } from './modules/slide';
 import type { Siblings } from './modules/siblings';
+import type { Bind } from './modules/bind';
 export type Selector = string | Node | Node[] | HTMLCollection | Curry;
 type CurryChainCompletion = boolean;
 export declare function $(selector: Selector, doc?: Document): Curry;
@@ -98,6 +99,7 @@ export declare class Curry {
     siblings: Siblings;
     prevSiblings: Siblings;
     nextSiblings: Siblings;
+    bind: Bind;
     /**
      * Functions which return Curry instance can be queued to be asyncronously executed.
      */
@@ -105,11 +107,11 @@ export declare class Curry {
     static fullscreen: StaticFullscreen;
     static replace: StaticReplace;
     static swap: StaticSwap;
-    static text(el: Selector, text: string | number): Curry;
     get length(): number;
     get await(): Promise<CurryChainCompletion>;
     /**
      *  Experimental extension API
+     *  Expose prototype so that users can extend curry with their own functions
      */
     static $fn(name: string, fn: (this: Curry) => void): void;
 }

--- a/dist/curry/modules/animate.d.ts
+++ b/dist/curry/modules/animate.d.ts
@@ -1,11 +1,10 @@
-import type { DataType, Properties } from 'csstype';
+import type { Properties } from 'csstype';
 import type { Curry } from '..';
 interface Options extends KeyframeAnimationOptions {
     onStart?: (animation: Animation) => void;
     onFinish?: (animation: Animation) => void;
-    onCancel?: (aniamtion: Animation, err: AnimationPlaybackEvent) => void;
+    onCancel?: (animation: Animation, err: AnimationPlaybackEvent) => void;
     keepStyle?: boolean;
-    easing?: DataType.EasingFunction;
 }
 export type Animate = (this: Curry, animator: Properties | Properties[], options?: Options) => Curry;
 /**

--- a/dist/curry/modules/bind.d.ts
+++ b/dist/curry/modules/bind.d.ts
@@ -1,0 +1,6 @@
+import type { Curry } from '..';
+export type Primitive = string | number | boolean | null | undefined;
+export type BindFn<T> = (this: HTMLElement, obj: T, instance: Curry) => void;
+export type RawObject = Record<PropertyKey, Primitive>;
+export type Bind = <T extends RawObject>(this: Curry, data: T, fn: BindFn<T>) => T;
+export declare const _bind: Bind;

--- a/dist/curry/modules/fullscreen.d.ts
+++ b/dist/curry/modules/fullscreen.d.ts
@@ -1,7 +1,7 @@
 import type { Curry } from '..';
 type MergedOptions = FullscreenOptions & {
-    onOpen?: () => void;
-    onError?: (error: Error) => void;
+    onOpen?: (this: string | Element | Node) => void;
+    onError?: (this: string | Element | Node, error: Error) => void;
 };
 export type StaticFullscreen = (target: string | Element | Node, options?: MergedOptions, doc?: Document) => Promise<void>;
 export type Fullscreen = (this: Curry, target?: string | Element | Node | MergedOptions, options?: MergedOptions) => void;

--- a/dist/curry/modules/key.d.ts
+++ b/dist/curry/modules/key.d.ts
@@ -1,5 +1,5 @@
 import type { Curry } from '..';
-import type { KeyboardeventCallback } from '../types';
+import type { KeyboardEventCallback } from '../types';
 import type { KeyboardEventKey } from '../keycodes';
 type KeyboardEvents = 'keydown' | 'keyup' | 'keypress';
 type Keys = KeyboardEventKey | KeyboardEventKey[];
@@ -15,21 +15,21 @@ export declare class Key {
      * @param keys Key or an array of keys (use capital letters for functional keys)
      * @param callback  Executed when the key(s) is/are pressed in the exact order
      */
-    down(keys: Keys, callback: KeyboardeventCallback): void;
+    down(keys: Keys, callback: KeyboardEventCallback): void;
     /**
      * Same as addEventListener('keyup')
      *
      * @param keys Key or an array of keys (use capital letters for functional keys)
      * @param callback  Executed when the key(s) is/are pressed in the exact order
      */
-    up(keys: Keys, callback: KeyboardeventCallback): void;
+    up(keys: Keys, callback: KeyboardEventCallback): void;
     /**
      * Same as addEventListener('keypress')
      *
      * @param keys Key or an array of keys (use capital letters for functional keys)
      * @param callback  Executed when the key(s) is/are pressed in the exact order
      */
-    press(keys: Keys, callback: KeyboardeventCallback): void;
+    press(keys: Keys, callback: KeyboardEventCallback): void;
 }
 export declare class History {
     registry: KeyboardEventKey[];
@@ -38,5 +38,5 @@ export declare class History {
     add(item: KeyboardEventKey): void;
     pressing(keys: KeyboardEventKey[]): boolean;
 }
-export declare function handleKeyPress(this: Curry, type: KeyboardEvents, keys: Keys, callback: KeyboardeventCallback): void;
+export declare function handleKeyPress(this: Curry, type: KeyboardEvents, keys: Keys, callback: KeyboardEventCallback): void;
 export {};

--- a/dist/curry/modules/query.d.ts
+++ b/dist/curry/modules/query.d.ts
@@ -1,11 +1,12 @@
 import type { Curry, Selector } from '..';
-export type Query = (this: Curry, selector: Selector) => Curry;
+export type Query = (this: Curry, selector: Selector, append?: boolean) => Curry;
 /**
  * Functions the same as $(SELECTOR) but within a chain. Meaning we can change the selected
  * elements without having to start a new chain.
  *
  * @param this Curry instance
  * @param selector Element or a string to search for in DOM
+ * @param append If set to true, old queried elements are preserved
  * @returns Curry instance for chaining
  */
 export declare const _query: Query;

--- a/dist/curry/modules/swap.d.ts
+++ b/dist/curry/modules/swap.d.ts
@@ -7,7 +7,7 @@ export type StaticSwap = (target: Element | Node | string, el: Element | Node | 
  * @returns Curry instance for chaining
  */
 export declare const _staticSwap: StaticSwap;
-export type Swap = (this: Curry, target: Element | Node | string, el: Element | Node | string, doc?: Document) => Curry;
+export type Swap = (this: Curry, target: Element | Node | string, el?: Element | Node | string, doc?: Document) => Curry;
 /**
  *
  * @param this Curry instance

--- a/dist/curry/modules/teleport.d.ts
+++ b/dist/curry/modules/teleport.d.ts
@@ -1,5 +1,5 @@
 import type { Curry } from '..';
-export type Teleport = (this: Curry, destination: Element | string) => Curry;
+export type Teleport = (this: Curry, destination: Element | Node | string) => Curry;
 /**
  *
  * @param this Curry instance

--- a/dist/curry/modules/wait.d.ts
+++ b/dist/curry/modules/wait.d.ts
@@ -3,8 +3,8 @@ export type Wait = (this: Curry, timeout: number) => Curry;
 /**
  * Method used to pause execution chain
  *
- * @param this Curry instace
- * @param timeout Length of pause in miliseconds
+ * @param this Curry instance
+ * @param timeout Length of pause in milliseconds
  * @returns Curry instance for chaining
  */
 export declare const _wait: Wait;

--- a/dist/curry/types.d.ts
+++ b/dist/curry/types.d.ts
@@ -8,7 +8,7 @@ interface CustomEventProperty extends Event {
     detail?: any;
 }
 export type EventCallback = (this: Element, event: CustomEventProperty, instance: Curry) => void;
-export type KeyboardeventCallback = (this: Element, event: KeyboardEvent, instance: Curry) => void;
+export type KeyboardEventCallback = (this: Element, event: KeyboardEvent, instance: Curry) => void;
 export type IteratorCallback<T = void> = (this: Element, options: {
     self: Element;
     instance: Curry;

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -1,1 +1,4 @@
 export { Curry, $, } from './curry';
+export { _staticFullscreen as fullscreen, } from './curry/modules/fullscreen';
+export { _staticReplace as replace, } from './curry/modules/replace';
+export { _staticSwap as swap, } from './curry/modules/swap';

--- a/index.html
+++ b/index.html
@@ -14,13 +14,7 @@
   </head>
   <body>
     <div id="app">
-     <ul>
-      <li>first</li>
-      <li>second</li>
-      <li>third</li>
-      <li>fourth</li>
-      <li>fifth</li>
-     </ul>
+     
     </div>
     <script type="module" src="/src/playground.ts"></script>
   </body>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dolanske/curry",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Fully typed, simple and powerful DOM manipulation library.",
   "author": "dolanske",
   "license": "MIT",

--- a/src/__test__/bind.test.ts
+++ b/src/__test__/bind.test.ts
@@ -1,0 +1,34 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { expect, test } from 'vitest'
+import { $, Curry } from '../curry'
+import { isNil } from '../curry/util'
+
+test('Reactive data binding', () => {
+  // Default state access
+  $(document).bind({
+    test: 10,
+  }, ({ test }, inst) => {
+    expect(test).toBe(10)
+    expect(inst).toBeInstanceOf(Curry)
+  })
+
+  // Update dom
+  const el = document.createElement('div')
+  const binding = $(el).bind({ count: 0 }, function ({ count }) {
+    this.textContent = isNil(count) ? '' : String(count)
+  })
+
+  expect(el.textContent).toBe('0')
+  binding.count++
+  expect(el.textContent).toBe('1')
+  binding.count = 10
+  expect(el.textContent).toBe('10')
+  expect(binding.count).toBe(10)
+
+  // @ts-expect-error We are deleting an existing property
+  delete binding.count
+  expect(el.textContent).toBe('')
+})

--- a/src/curry/index.ts
+++ b/src/curry/index.ts
@@ -155,6 +155,7 @@ export class Curry {
   prevSiblings: Siblings = _prevSiblings.bind(this)
   nextSiblings: Siblings = _nextSiblings.bind(this)
   // Experimental
+  // @ts-expect-error I don't really understand this problem, sorry :/
   bind: Bind = _bind.bind(this)
 
   /**

--- a/src/curry/index.ts
+++ b/src/curry/index.ts
@@ -74,6 +74,8 @@ import { _slideDown, _slideToggle, _slideUp } from './modules/slide'
 import type { Slide, SlideToggle } from './modules/slide'
 import type { Siblings } from './modules/siblings'
 import { _nextSiblings, _prevSiblings, _siblings } from './modules/siblings'
+import type { Bind } from './modules/bind'
+import { _bind } from './modules/bind'
 
 // TODO: every method using document.querySelector should be able to substitude a different dom selector
 // from the `this.doc` variable. Meaning we can scope down DOM searching
@@ -152,6 +154,8 @@ export class Curry {
   siblings: Siblings = _siblings.bind(this)
   prevSiblings: Siblings = _prevSiblings.bind(this)
   nextSiblings: Siblings = _nextSiblings.bind(this)
+  // Experimental
+  bind: Bind = _bind.bind(this)
 
   /**
    * Functions which return Curry instance can be queued to be asyncronously executed.
@@ -166,10 +170,6 @@ export class Curry {
   static fullscreen: StaticFullscreen = _staticFullscreen
   static replace: StaticReplace = _staticReplace
   static swap: StaticSwap = _staticSwap
-  // static text(el: Selector, text: string | number) {
-  //   const instance = $(el)
-  //   return _text.bind(instance)(text)
-  // }
 
   get length() {
     return this.nodes.length
@@ -183,9 +183,9 @@ export class Curry {
     })
   }
 
-  // Expose prototype so that users can extend curry with their own functions
   /**
    *  Experimental extension API
+   *  Expose prototype so that users can extend curry with their own functions
    */
 
   static $fn(name: string, fn: (this: Curry) => void) {

--- a/src/curry/modules/bind.ts
+++ b/src/curry/modules/bind.ts
@@ -1,0 +1,34 @@
+import type { Curry } from '..'
+import { toEl } from '../util'
+
+export type Primitive = string | number | boolean | null | undefined
+export type BindFn<T> = (this: HTMLElement, obj: T, instance: Curry) => void
+export type RawObject = Record<PropertyKey, Primitive>
+export type Bind = <T extends RawObject>(this: Curry, data: T, fn: BindFn<T>) => T
+
+export const _bind: Bind = function (this, data, fn) {
+  // Apply base state first
+  for (const node of this.nodes)
+    fn.apply(toEl(node), [data, this])
+
+  // Create proxy object which runs the fn each time a property is set or deleted
+  return new Proxy(data, {
+    get: (target: typeof data, prop: keyof typeof data, receiver: any) => {
+      return Reflect.get(target, prop, receiver)
+    },
+    set: (target: typeof data, key: keyof typeof data, value: any, receiver: any) => {
+      const result = Reflect.set(target, key, value, receiver)
+      for (const node of this.nodes)
+        fn.apply(toEl(node), [target, this])
+
+      return result
+    },
+    deleteProperty: (target: typeof data, prop: keyof typeof data) => {
+      const result = Reflect.deleteProperty(target, prop)
+      for (const node of this.nodes)
+        fn.apply(toEl(node), [target, this])
+
+      return result
+    },
+  })
+}

--- a/src/playground.ts
+++ b/src/playground.ts
@@ -1,5 +1,10 @@
-// $('button').hover().text('hello')
-
 import { $ } from './curry'
 
-$('ul > li').filter([':nth-child(2)']).text('I am second!')
+// Automatically runs a callback fn whenever the object property is changed or deleted
+// 1. Create a variable using the bind function
+const content = $('#app').bind({ msg: 'Hello' }, function ({ msg }) {
+  this.textContent = msg
+})
+
+// 2. Change variable anywhere on the code
+content.msg = 'It works!!'


### PR DESCRIPTION
This PR adds a new method to the chain called `$.bind` which allows you to reactively update DOM depending on the supplied data object.

Please refer to the documentation for more information